### PR TITLE
Remove "expires_at" property

### DIFF
--- a/server/lib/box.js
+++ b/server/lib/box.js
@@ -184,7 +184,6 @@ export const getAppUserToken = (user, token) =>
           }
 
           const boxToken = body;
-          boxToken.expires_at = Date.now() + 2700000;
           return resolve(boxToken);
         });
       });


### PR DESCRIPTION
For issues with timestamp formatting, differences in server time and client time, and allowing for more optional control of expiring a token according to what each developer may want, I wanted to propose removing the expires_at field for this token.